### PR TITLE
Fix: error: ‘winstack.stack’ may be used uninitialized [-Werror=maybe-uninitialized]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/build/*
 
 # Created by https://www.gitignore.io/api/c,cmake,linux,clion+all,visualstudio,visualstudiocode
 # Edit at https://www.gitignore.io/?templates=c,cmake,linux,clion+all,visualstudio,visualstudiocode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(concorde LANGUAGES C)
 
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-set(WARNING_OPTIONS             -Wall -Wextra -Werror)
+# set(WARNING_OPTIONS             -Wall -Wextra -Werror)
+set(WARNING_OPTIONS             -Wall -Wextra)
 set(RELEASE_OPTIONS             -O3)
 set(DEBUG_OPTIONS               -O0)
 set(GDB_DEBUG_OPTIONS           -ggdb3)

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ I also assume that you are interested in having the following, and nothing else,
 
 ## Building
 
-Assume that you have Cplex installed in `/opt/ibm/CPLEX/my-cplex`.
+Assume that you have Cplex installed in `/opt/ibm/ILOG/CPLEX_Studio1210/`.
 Building Concorde, then, is as simple as:
 
 ```
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release -DCPLEX_ROOT_DIR=/opt/ibm/CPLEX/my-cplex ..
+cmake -DCMAKE_BUILD_TYPE=Release -DCPLEX_ROOT_DIR=/opt/ibm/ILOG/CPLEX_Studio1210/ ..
 make -j5
 ```
 


### PR DESCRIPTION
Handling the issue in https://github.com/alberto-santini/concorde-easy-build/issues/1

This PR simply removes the `-Werror` flag to ignore the "warning."


Tested on Ubuntu 22.04 with CPLEX 12.10, `gcc version 11.4.0`, `cmake version 3.22.1`


